### PR TITLE
Support for Hazelcast 4.0 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.idvp.infrastructure</groupId>
     <artifactId>quartz-hazelcast-jobstore</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
   
     <name>Quartz Hazelcast JobStore</name>
@@ -18,7 +18,7 @@
         <!-- Logging -->
         <slf4j.version>1.7.7</slf4j.version>
 
-        <hazelcast.version>3.11</hazelcast.version>
+        <hazelcast.version>4.0.3</hazelcast.version>
         <quartz.version>2.3.0</quartz.version>
         <org.jetbrains.annotations.version>16.0.3</org.jetbrains.annotations.version>
     </properties>
@@ -36,13 +36,6 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz-jobs</artifactId>
             <version>${quartz.version}</version>
-            <scope>compile</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
-            <version>${hazelcast.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/ClusteredJobStore.java
+++ b/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/ClusteredJobStore.java
@@ -15,7 +15,7 @@
 
 package com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast;
 
-import com.hazelcast.core.MembershipListener;
+import com.hazelcast.cluster.MembershipListener;
 import org.quartz.spi.JobStore;
 
 @SuppressWarnings("unused")

--- a/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/collections/InstanceHolder.java
+++ b/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/collections/InstanceHolder.java
@@ -15,10 +15,10 @@
 
 package com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.collections;
 
+import com.hazelcast.collection.ISet;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ILock;
-import com.hazelcast.core.IMap;
-import com.hazelcast.core.ISet;
+import com.hazelcast.cp.lock.FencedLock;
+import com.hazelcast.map.IMap;
 import com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.wrappers.FiredTrigger;
 import com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.wrappers.JobWrapper;
 import com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.wrappers.TriggerWrapper;
@@ -214,8 +214,8 @@ public class InstanceHolder {
         return timeTriggerSetReference.get();
     }
 
-    public ILock getLock() {
+    public FencedLock getLock() {
         String lockName = generateName(SINGLE_LOCK_NAME_PREFIX);
-        return toolkit.getLock(lockName);
+        return toolkit.getCPSubsystem().getLock(lockName);
     }
 }

--- a/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/collections/TimeTriggerSet.java
+++ b/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/collections/TimeTriggerSet.java
@@ -15,7 +15,7 @@
 
 package com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.collections;
 
-import com.hazelcast.core.ISet;
+import com.hazelcast.collection.ISet;
 import com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.wrappers.TriggerWrapper;
 import org.quartz.TriggerKey;
 

--- a/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/wrappers/FiredTrigger.java
+++ b/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/wrappers/FiredTrigger.java
@@ -19,25 +19,26 @@ import org.quartz.TriggerKey;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.UUID;
 
 public class FiredTrigger implements Serializable {
-    private final String clientId;
+    private final UUID clientId;
     private final TriggerKey triggerKey;
     private final long scheduledFireTime;
     private final long fireTime;
 
-    public FiredTrigger(String clientId, TriggerKey triggerKey, long scheduledFireTime) {
+    public FiredTrigger(UUID clientId, TriggerKey triggerKey, long scheduledFireTime) {
         this(clientId, triggerKey, scheduledFireTime, System.currentTimeMillis());
     }
 
-    public FiredTrigger(String clientId, TriggerKey triggerKey, long scheduledFireTime, long now) {
+    public FiredTrigger(UUID clientId, TriggerKey triggerKey, long scheduledFireTime, long now) {
         this.clientId = clientId;
         this.triggerKey = triggerKey;
         this.scheduledFireTime = scheduledFireTime;
         this.fireTime = now;
     }
 
-    public String getClientId() {
+    public UUID getClientId() {
         return clientId;
     }
 

--- a/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/wrappers/JobFacade.java
+++ b/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/wrappers/JobFacade.java
@@ -15,7 +15,7 @@
 
 package com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.wrappers;
 
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.collections.InstanceHolder;
 import org.quartz.JobKey;
 

--- a/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/wrappers/TriggerFacade.java
+++ b/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/wrappers/TriggerFacade.java
@@ -15,7 +15,7 @@
 
 package com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.wrappers;
 
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import com.idvp.data.infrastructure.scheduling.quarz.store.hazelcast.collections.InstanceHolder;
 import org.quartz.JobKey;
 import org.quartz.TriggerKey;

--- a/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/wrappers/TriggerWrapper.java
+++ b/src/main/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/wrappers/TriggerWrapper.java
@@ -22,6 +22,7 @@ import org.quartz.spi.OperableTrigger;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.UUID;
 
 @SuppressWarnings("BooleanMethodIsAlwaysInverted")
 public class TriggerWrapper implements Serializable {
@@ -31,7 +32,7 @@ public class TriggerWrapper implements Serializable {
 
     private final boolean jobDisallowsConcurrence;
 
-    private volatile String lastHazelcastClientId = null;
+    private volatile UUID lastHazelcastClientId = null;
     private volatile TriggerState state = TriggerState.WAITING;
 
     private final OperableTrigger trigger;
@@ -50,7 +51,7 @@ public class TriggerWrapper implements Serializable {
         return jobDisallowsConcurrence;
     }
 
-    public String getLastHazelcastClientId() {
+    public UUID getLastHazelcastClientId() {
         return lastHazelcastClientId;
     }
 
@@ -72,7 +73,7 @@ public class TriggerWrapper implements Serializable {
         return trigger.getJobKey();
     }
 
-    public void setState(TriggerState state, String hazelcastId, TriggerFacade triggerFacade) {
+    public void setState(TriggerState state, UUID hazelcastId, TriggerFacade triggerFacade) {
         if (hazelcastId == null) {
             throw new NullPointerException();
         }

--- a/src/test/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/AbstractTest.java
+++ b/src/test/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/AbstractTest.java
@@ -22,9 +22,8 @@ public abstract class AbstractTest {
     HazelcastInstance createHazelcastInstance(String clusterName) {
 
         Config config = new Config();
-        config.getGroupConfig().setName(clusterName);
+        config.setClusterName(clusterName);
         //noinspection deprecation
-        config.getGroupConfig().setPassword("some-password");
         config.setProperty("hazelcast.logging.type", "slf4j");
         config.setProperty("hazelcast.heartbeat.interval.seconds", "1");
         config.setProperty("hazelcast.max.no.heartbeat.seconds", "3");

--- a/src/test/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/QuartzTest.java
+++ b/src/test/java/com/idvp/data/infrastructure/scheduling/quarz/store/hazelcast/QuartzTest.java
@@ -50,7 +50,7 @@ public class QuartzTest extends AbstractTest {
 
         Config config = new Config();
         config.setProperty("hazelcast.logging.type", "slf4j");
-        config.getGroupConfig().setName(UUID.randomUUID().toString());
+        config.setClusterName(UUID.randomUUID().toString());
 
         hazelcastInstance = Hazelcast.newHazelcastInstance(config);
         HazelcastJobStoreDelegate.setInstance(hazelcastInstance);


### PR DESCRIPTION
Hello, 

we are using old version of quartz-scheduler-hazelcast-jobstore with hazelcast 3.x version... from Spring Boot 2.4 there is now used Hazelcast 4.0.3 therefore I did following changes to make this lib compile with that version.

It is rather a simplistic attempt to make it work with Hazelcast 4.0.3. I did try Hazelcast 4.1 also and it seems to be working at least tests are passing. Would be nice if someone with deeper knowledge of Hazelcast could examine changes.

Hazelcast from version 3.12 uses [CP Subsystem](https://hazelcast.com/blog/hazelcast-imdg-3-12-introduces-cp-subsystem/) when I did some tests with 2 member (CP Unsafe) or 3 members it didn't seems to be problematic however there is one log entry which I'm not sure of its meaning and consequences: 

`2020-12-09 16:22:50.605  INFO -- [ion.thread-2] c.h.c.i.session.RaftSessionService       : [localhost]:8877 [test:cluster] [4.0.3] Created new session: 3 in CPGroupId{name='_tc_quartz_single_lock|schedulerFactoryBean', seed=0, groupId=178} f
or SERVER -> [localhost]:8877 `

It  logs creation of a new session from time to time and I'm not really sure of this behaviour.